### PR TITLE
When creating the Gist, use filename specified in the Create Gist dialog.

### DIFF
--- a/GistsVSIX/CreateGist.cs
+++ b/GistsVSIX/CreateGist.cs
@@ -151,6 +151,7 @@ namespace Microsoft.VisualStudio.Extensions.Gists
                         codeToPublish = GetAllTextFromEditor(viewHost);
                     }
 
+                    filename = publishDialog.Filename;
 
                     var gistFiles = new[] { Tuple.Create(filename, codeToPublish) };
 


### PR DESCRIPTION
The filename specified in the dialog is not used when the Gist is created. I believe this fixes it. Could not test because when I built the extension the Github auth dialog displays a 404 error.